### PR TITLE
DNS + Argo Changes

### DIFF
--- a/terraform/argo.tf
+++ b/terraform/argo.tf
@@ -1,0 +1,5 @@
+resource "cloudflare_argo" "hideout_argo" {
+  zone_id        = var.CLOUDFLARE_ZONE_ID
+  tiered_caching = "on"
+  smart_routing  = "off" # costs $5 per month minimum
+}

--- a/terraform/argo.tf
+++ b/terraform/argo.tf
@@ -1,5 +1,4 @@
 resource "cloudflare_argo" "hideout_argo" {
   zone_id        = var.CLOUDFLARE_ZONE_ID
   tiered_caching = "on"
-  smart_routing  = "off" # costs $5 per month minimum
 }

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -18,19 +18,19 @@ resource "cloudflare_record" "www" {
 
 resource "cloudflare_record" "api" {
   name    = "api"
-  proxied = false
+  proxied = true
   ttl     = 1
   type    = "CNAME"
-  value   = "ecp.map.fastly.net"
+  value   = "api.hideout-api.workers.dev"
   zone_id = var.CLOUDFLARE_ZONE_ID
 }
 
 resource "cloudflare_record" "dev_api" {
   name    = "dev-api"
-  proxied = false
+  proxied = true
   ttl     = 1
   type    = "CNAME"
-  value   = "ecp.map.fastly.net"
+  value   = "api-development.hideout-api.workers.dev"
   zone_id = var.CLOUDFLARE_ZONE_ID
 }
 


### PR DESCRIPTION
# DNS + Argo Changes

This PR updates the DNS record to go back to their normal state after our whimsical journey with GraphCDN. For now, we will just use native Cloudflare DNS for our edge workers.

This PR also introduces "Argo" which is intelligent tiered caching by Cloudflare. It will help reduce hits to origin and may even offer some speed boosts for page content loading from our CDN. 