### PR TITLE
bump to v1.4.2

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: branch-deploy
         id: branch-deploy
-        uses: GrantBirki/branch-deploy@6a8b745b4bd3fb98fb231bde69c45fb149f8e2c5 # pin@v1.4.0
+        uses: GrantBirki/branch-deploy@5d7ea46552d858242fa4bf16625e9f29b1ee1b63 # pin@v1.4.2
 
       - name: Checkout
         if: steps.branch-deploy.outputs.continue == 'true'


### PR DESCRIPTION
# Bump `branch-deploy` Action to v1.4.2

This PR updates the `branch-deploy` Action to use the latest version which includes one minor bug fix