### PR TITLE
socket to railway

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -66,7 +66,7 @@ resource "cloudflare_record" "socket" {
   proxied = true
   ttl     = 1
   type    = "CNAME"
-  value   = "hideout-socket-server.herokuapp.com"
+  value   = "tarkov-socket-server-production.up.railway.app"
   zone_id = var.CLOUDFLARE_ZONE_ID
 }
 

--- a/terraform/page_rules.tf
+++ b/terraform/page_rules.tf
@@ -97,3 +97,14 @@ resource "cloudflare_page_rule" "images" {
     edge_cache_ttl    = 2678400
   }
 }
+
+resource "cloudflare_page_rule" "socket_service" {
+  priority = 9
+  status   = "active"
+  target   = "socket.tarkov.dev/*"
+  zone_id  = var.CLOUDFLARE_ZONE_ID
+
+  actions {
+    ssl = "strict"
+  }
+}


### PR DESCRIPTION
Points our `socket` dns record to railway as we have migrated off heroku