### PR TITLE
Redirect monitor queue requests

### DIFF
--- a/terraform/redirect_rules.tf
+++ b/terraform/redirect_rules.tf
@@ -50,7 +50,7 @@ resource "cloudflare_ruleset" "redirect_rules" {
     action      = "redirect"
     description = "Streamer domain graphql requests"
     enabled     = true
-    expression  = "(http.request.full_uri eq \"https://streamer.tarkov.dev/graphql\")"
+    expression  = "(starts_with(http.request.full_uri, \"https://streamer.tarkov.dev/graphql\"))"
 
     action_parameters {
       automatic_https_rewrites   = false
@@ -168,6 +168,48 @@ resource "cloudflare_ruleset" "redirect_rules" {
 
         target_url {
           value = "https://api.tarkov.dev/___graphql"
+        }
+      }
+    }
+  }
+  rules {
+    action      = "redirect"
+    description = "Monitor API to Data Manager API"
+    enabled     = true
+    expression  = "(starts_with(http.request.full_uri, \"https://monitor.tarkov.dev/api\"))"
+
+    action_parameters {
+      automatic_https_rewrites   = false
+      bic                        = false
+      cache                      = false
+      cookie_fields              = []
+      disable_apps               = false
+      disable_railgun            = false
+      disable_zaraz              = false
+      email_obfuscation          = false
+      hotlink_protection         = false
+      increment                  = 0
+      mirage                     = false
+      opportunistic_encryption   = false
+      origin_error_page_passthru = false
+      phases                     = []
+      products                   = []
+      request_fields             = []
+      respect_strong_etags       = false
+      response_fields            = []
+      rocket_loader              = false
+      rules                      = {}
+      rulesets                   = []
+      server_side_excludes       = false
+      status_code                = 0
+      sxg                        = false
+
+      from_value {
+        preserve_query_string = true
+        status_code           = 308
+
+        target_url {
+          value = "https://manager.tarkov.dev/api/queue"
         }
       }
     }


### PR DESCRIPTION
Fixes bug with the streamer URL redirect.
Allows us to redirect requests for queue time submissions.