### PR TITLE
Point cache.tarkov.dev at the TDM VPS

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -76,7 +76,7 @@ resource "cloudflare_record" "cache" {
   proxied = true
   ttl     = 1
   type    = "A"
-  value   = "135.148.148.174"
+  value   = "158.69.0.117"
   zone_id = var.CLOUDFLARE_ZONE_ID
 }
 


### PR DESCRIPTION
Updates the cache DNS record from the old standalone VPS to the TDM VPS. This PR should stay separate from the service-migration PRs and merge only after the new cache and standalone ingress stacks are verified on the TDM host and you are ready to cut over DNS.