### PR TITLE
Remove dns records

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -116,24 +116,6 @@ resource "cloudflare_dns_record" "dedapi" {
   zone_id = var.CLOUDFLARE_ZONE_ID
 }
 
-resource "cloudflare_dns_record" "fence" {
-  content = "fence-worker.hideout-api.workers.dev"
-  name    = "fence"
-  proxied = true
-  ttl     = 1
-  type    = "CNAME"
-  zone_id = var.CLOUDFLARE_ZONE_ID
-}
-
-resource "cloudflare_dns_record" "imagemagic" {
-  content = "image-generator-worker.hideout-api.workers.dev"
-  name    = "imagemagic"
-  proxied = true
-  ttl     = 1
-  type    = "CNAME"
-  zone_id = var.CLOUDFLARE_ZONE_ID
-}
-
 resource "cloudflare_dns_record" "json_dev" {
   content = "public.r2.dev"
   name    = "json-dev"
@@ -146,15 +128,6 @@ resource "cloudflare_dns_record" "json_dev" {
 resource "cloudflare_dns_record" "json" {
   content = "public.r2.dev"
   name    = "json"
-  proxied = true
-  ttl     = 1
-  type    = "CNAME"
-  zone_id = var.CLOUDFLARE_ZONE_ID
-}
-
-resource "cloudflare_dns_record" "player" {
-  content = "player-stats-worker.hideout-api.workers.dev"
-  name    = "player"
   proxied = true
   ttl     = 1
   type    = "CNAME"

--- a/terraform/tests/static_configuration.tftest.hcl
+++ b/terraform/tests/static_configuration.tftest.hcl
@@ -88,11 +88,8 @@ run "static_configuration" {
         cloudflare_dns_record.streamer,
         cloudflare_dns_record.players,
         cloudflare_dns_record.dedapi,
-        cloudflare_dns_record.fence,
-        cloudflare_dns_record.imagemagic,
         cloudflare_dns_record.json_dev,
         cloudflare_dns_record.json,
-        cloudflare_dns_record.player,
       ] : contains(["A", "CNAME"], record.type) &&
       record.proxied &&
       record.ttl == 1 &&


### PR DESCRIPTION
The removed entries are now handled in the worker configs and no longer needed.