### PR TITLE
Stop managing URL normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ This repository uses Terraform to manage the configuration and state for support
 - [`Cache Rules`](terraform/cache_rules.tf)
 - [`Configuration Rules`](terraform/config_rules.tf)
 - [`Tiered Cache`](terraform/tiered_cache.tf)
-- [`URL Normalization`](terraform/url_normalization.tf)
 
 Because this repository is public, we intentionally keep sensitive records, Worker code, Worker bindings, Pages secrets, KV contents, and private security posture out of source control and only manage the safe subset here.
 

--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -1,4 +1,0 @@
-import {
-  to = cloudflare_dns_record.streamer
-  id = "a17204c79af55fcf05e4975f66e2490e/ef37d2128e2a7e2e5865e2304198394f"
-}

--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -1,0 +1,4 @@
+import {
+  to = cloudflare_dns_record.streamer
+  id = "a17204c79af55fcf05e4975f66e2490e/ef37d2128e2a7e2e5865e2304198394f"
+}

--- a/terraform/tests/static_configuration.tftest.hcl
+++ b/terraform/tests/static_configuration.tftest.hcl
@@ -143,8 +143,6 @@ run "static_configuration" {
   assert {
     condition = (
       cloudflare_zone_dnssec.tarkov_dev.status == "disabled" &&
-      cloudflare_url_normalization_settings.tarkov_dev.scope == "incoming" &&
-      cloudflare_url_normalization_settings.tarkov_dev.type == "cloudflare" &&
       cloudflare_tiered_cache.tarkov_dev.value == "on" &&
       cloudflare_zone_setting.settings["ssl"].value == "flexible" &&
       cloudflare_zone_setting.settings["security_level"].value == "medium"

--- a/terraform/tests/static_configuration.tftest.hcl
+++ b/terraform/tests/static_configuration.tftest.hcl
@@ -37,6 +37,10 @@ override_resource {
 }
 
 override_resource {
+  target = cloudflare_dns_record.streamer
+}
+
+override_resource {
   target = cloudflare_dns_record.google_site_verification_tertiary
 }
 

--- a/terraform/url_normalization.tf
+++ b/terraform/url_normalization.tf
@@ -1,5 +1,9 @@
-resource "cloudflare_url_normalization_settings" "tarkov_dev" {
-  scope   = "incoming"
-  type    = "cloudflare"
-  zone_id = var.CLOUDFLARE_ZONE_ID
+# Cloudflare rejects /url_normalization for scoped API tokens even when normal
+# zone settings endpoints are authorized, so keep the live setting unmanaged.
+removed {
+  from = cloudflare_url_normalization_settings.tarkov_dev
+
+  lifecycle {
+    destroy = false
+  }
 }


### PR DESCRIPTION
## Summary

This stops managing Cloudflare URL Normalization in Terraform by replacing the resource with a `removed` block using `destroy = false`, which lets Terraform forget the state address without deleting the live setting.

The static Terraform test and README managed-resource list now match that behavior, so `.noop` runs should no longer fail on the `/url_normalization` API authorization error.
